### PR TITLE
fix replacing imgpath

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -178,7 +178,9 @@ function! previm#relative_to_absolute_imgpath(text, mkd_dir)
   " 半角空白だけはエラーの原因になるのでURLエンコード対象とする
   let pre_slash = s:start_with(a:mkd_dir, '/') ? '' : '/'
   let local_path = substitute(a:mkd_dir.'/'.elem.path, ' ', '%20', 'g')
-  return printf('![%s](file://localhost%s%s)', elem.title, pre_slash, local_path)
+  let prev_imgpath = printf('!\[%s\](%s)', elem.title, elem.path)
+  let new_imgpath = printf('![%s](file://localhost%s%s)', elem.title, pre_slash, local_path)
+  return substitute(a:text, prev_imgpath, new_imgpath, '')
 endfunction
 
 function! previm#fetch_imgpath_elements(text)

--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -174,10 +174,14 @@ function! previm#relative_to_absolute_imgpath(text, mkd_dir)
     endif
   endfor
 
+  " escape backslash
+  let dir = substitute(a:mkd_dir, '\\', '\\\\', 'g')
+  let elem.path = substitute(elem.path, '\\', '\\\\', 'g')
+
   " マルチバイトの解釈はブラウザに任せるのでURLエンコードしない
   " 半角空白だけはエラーの原因になるのでURLエンコード対象とする
-  let pre_slash = s:start_with(a:mkd_dir, '/') ? '' : '/'
-  let local_path = substitute(a:mkd_dir.'/'.elem.path, ' ', '%20', 'g')
+  let pre_slash = s:start_with(dir, '/') ? '' : '/'
+  let local_path = substitute(dir.'/'.elem.path, ' ', '%20', 'g')
   let prev_imgpath = printf('!\[%s\](%s)', elem.title, elem.path)
   let new_imgpath = printf('![%s](file://localhost%s%s)', elem.title, pre_slash, local_path)
   return substitute(a:text, prev_imgpath, new_imgpath, '')


### PR DESCRIPTION
1つの行に画像のパスのみでない場合(例えば画像を含む表)に対応しました。具体的には以下のMarkdownソースで正しく変換できるようにしました。

```
| name | image |
| - | ---- |
| a | ![image1](1.png) |
| b | ![image2](2.png) |
| c | ![image3](3.png) |
```

ただし、1つの行に複数の画像のパスを含む場合には対応していません。