### PR TITLE
Escape html-tags in code block

### DIFF
--- a/preview/js/previm.js
+++ b/preview/js/previm.js
@@ -3,11 +3,13 @@
 (function(_doc, _win) {
   var REFRESH_INTERVAL = 1000;
   var marked_renderer = new marked.Renderer();
+  var defaultCodeBlockRenderer = marked_renderer.code;
+
   marked_renderer.code = function (code, language) {
     if(language === 'mermaid'){
       return '<div class="mermaid">' + code + '</div>';
     } else {
-      return '<pre><code>' + code + '</code></pre>';
+      return defaultCodeBlockRenderer.apply(this, arguments);
     }
   };
 


### PR DESCRIPTION
いつも便利にprevimを使わせていただいております。

コードブロック部分の表示についてなのですが、ブロック内の`<`や`>`といった文字がエスケープされていませんでした。なので例えば以下のようなコードブロックを書くと、`<C-u>`や`<Space>`が通常のHTMLタグとして解釈されてしまい、画面に表示されません。
(`\`はgithubにmarkdownと解釈されないよう便宜的につけています)

```
\```
nnoremap <C-h> :<C-u>help<Space>
\```
```
ブラウザ上の表示:
```
nnoremap :help
```

#38 の修正で`mermaid`をサポートした際、`marked.Renderer.code`関数をオーバーライドした事でエスケープされなくなってしまったようです。デフォルトの`code`関数はエスケープもしてくれるので、`mermaid`でないコードブロックにはそのままデフォルトの`code`関数を使うよう修正しました。
