### PR TITLE
Remove opacity of .section because it cannot see in rst file.

### DIFF
--- a/preview/css/lib/mermaid.css
+++ b/preview/css/lib/mermaid.css
@@ -87,7 +87,6 @@ text.actor {
 /** Section styling */
 .section {
   stroke: none;
-  opacity: 0.2;
 }
 .section0 {
   fill: rgba(102, 102, 255, 0.49);
@@ -98,7 +97,6 @@ text.actor {
 .section1,
 .section3 {
   fill: white;
-  opacity: 0.2;
 }
 .sectionTitle0 {
   fill: #333333;


### PR DESCRIPTION
## Summary
mermaid.cssでsectionに指定しているCSSの影響で、
CSS指定したdivタグの内容がほぼ見えなくなっているのでopacityの設定を削除しました。

#43 の件もこれが影響していたと思われます。
ご確認よろしくお願いします。

## Screen shot
### Before
![before](https://cloud.githubusercontent.com/assets/1122795/15310635/e8af4790-1c2c-11e6-8c7f-65835286cd91.png)

### After
![after](https://cloud.githubusercontent.com/assets/1122795/15310637/f079ed86-1c2c-11e6-9cea-0f045bf6df1e.png)