### PR TITLE
fix image paths on Windows

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -163,6 +163,8 @@ function! previm#convert_to_content(lines) abort
   if has('win32unix')
     " convert cygwin path to windows path
     let mkd_dir = s:escape_backslash(substitute(system('cygpath -wa ' . mkd_dir), "\n$", '', ''))
+  elseif has('win32') || has('win64')
+    let mkd_dir = substitute(mkd_dir, '\\', '/', 'g')
   endif
   let converted_lines = []
   for line in s:do_external_parse(a:lines)


### PR DESCRIPTION
mkd_dir should be path-slash-ed always on Windows. backslash are replaced double. ex: `\` to `\\`, and it will be `%5c`. To avoid this problem, replace backslashs to slash in mkd_dir always on Windows. 