### PR TITLE
Fix bloated issues #82 while conforming to #65

### DIFF
--- a/preview/css/origin.css
+++ b/preview/css/origin.css
@@ -205,7 +205,7 @@ dl dd > :last-child {
   margin-bottom: 0;
 }
 img {
-  width: 100%;
+  max-width: 100%;
 }
 
 .shadow {


### PR DESCRIPTION
Changes the `width` property to a `max-width` property so that small
images aren't blown up, while large images are scaled down.  

Referencing #82 and #65.