### PR TITLE
change index.html path to double quotation from single at windows-fir…

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -13,7 +13,7 @@ function! previm#open(preview_html_file) abort
   if exists('g:previm_open_cmd') && !empty(g:previm_open_cmd)
     if has('win32') || has('win64') && g:previm_open_cmd =~? 'firefox'
       " windows+firefox環境
-      call s:system(g:previm_open_cmd . ' '''  . substitute(a:preview_html_file,'\/','\\','g') . '''')
+      call s:system(g:previm_open_cmd . ' "'  . substitute(a:preview_html_file,'\/','\\','g') . '"')
     else
       call s:system(g:previm_open_cmd . ' '''  . a:preview_html_file . '''')
     endif


### PR DESCRIPTION
…efox environment

In windows, since the path sometimes includes spaces, it need to be surrounded by double-quotation.
This fixes #62 .

Windows環境ではスペースの処理のためファイルパスはダブルクオーテーション(")で括ります。シングルクォーテーション(')であったためfirefoxはファイルパスを認識できていませんでした。Chrome等他のブラウザでのファイルパス解釈について詳しくないため、issueにあるfirefoxのみを対象としたPRです。