### PR TITLE
Add Cygwin support.

### DIFF
--- a/autoload/previm.vim
+++ b/autoload/previm.vim
@@ -14,6 +14,8 @@ function! previm#open(preview_html_file) abort
     if has('win32') || has('win64') && g:previm_open_cmd =~? 'firefox'
       " windows+firefox環境
       call s:system(g:previm_open_cmd . ' '''  . substitute(a:preview_html_file,'\/','\\','g') . '''')
+    elseif has('win32unix') || has('win64unix')
+      call s:system(g:previm_open_cmd . ' '''  . system('cygpath -w ' . a:preview_html_file) . '''')
     else
       call s:system(g:previm_open_cmd . ' '''  . a:preview_html_file . '''')
     endif
@@ -22,6 +24,8 @@ function! previm#open(preview_html_file) abort
     " fix temporary(the cause unknown)
     if has('win32') || has('win64')
       let path = fnamemodify(path, ':p:gs?\\?/?g')
+    elseif has('win32unix') || has('win64unix')
+      let path = substitute(path,'\/','','')
     endif
     call s:apply_openbrowser('file:///' . path)
   else


### PR DESCRIPTION
cygwin環境下で、open-browserを使っていた場合、

> opening 'file:////home/USER/.vim/dein/.cache/vimrc/.dein/autoload/../preview/index.html' ... done! (cygstart)

となり（スラッシュが４つ）、ブラウザが立ち上がらなかったため修正しました。
合わせて、open-browserを使っていない場合、ブラウザは立ち上がるものの該当ファイルを開けなかったので、修正しました。

-----

:PrevimOpen does not work on Cygwin environment regardless of using open-brower or not.
In case using open-browser, the file URI scheme is not "file:///" but "file:////" shown as below, so that the browser does not start-up.

> opening 'file:////home/USER/.vim/dein/.cache/vimrc/.dein/autoload/../preview/index.html' ... done! (cygstart)

In case not using open-browser, it passes file path in not Windows style but Unix style, so that the browser start-up without opening any file.
